### PR TITLE
Fix time zone specific test units

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This framework targets iOS 8 and later exclusively.
 
 ## Installation
 
-With [CocoaPods](http://cocoapods.org/), just add this to your Podfile:
+SwiftMoment is compatible with [Carthage(http://github.com/Carthage/Carthage) and [CocoaPods](http://cocoapods.org/). With CocoaPods, just add this to your Podfile:
 
 ```ruby
 pod 'SwiftMoment'

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This framework targets iOS 8 and later exclusively.
 
 ## Installation
 
-SwiftMoment is compatible with [Carthage(http://github.com/Carthage/Carthage) and [CocoaPods](http://cocoapods.org/). With CocoaPods, just add this to your Podfile:
+SwiftMoment is compatible with [Carthage](http://github.com/Carthage/Carthage) and [CocoaPods](http://cocoapods.org/). With CocoaPods, just add this to your Podfile:
 
 ```ruby
 pod 'SwiftMoment'

--- a/SwiftMoment/Moment.swift
+++ b/SwiftMoment/Moment.swift
@@ -126,6 +126,7 @@ public func moment(params: [Int]
         }
         
         if let date = calendar.dateFromComponents(components) {
+            println(timeZone.abbreviation)
             return moment(date, timeZone: timeZone, locale: locale)
         }
     }

--- a/SwiftMomentTests/MomentTests.swift
+++ b/SwiftMomentTests/MomentTests.swift
@@ -110,8 +110,9 @@ class MomentTests: XCTestCase {
     }
     
     func testCanCreateWeirdDateFromComponents() {
-        let obj = moment([-2015445, 76, -46, 876, 234565, -999])!
-        XCTAssertEqual(obj.format(), "2015440-02-13 12:57:81 GMT+00:34:08", "The date is weird...!")
+        let timeZone = NSTimeZone(abbreviation: "GMT+01")!
+        let obj = moment([-2015445, 76, -46, 876, 234565, -999], timeZone: timeZone)!
+        XCTAssertEqual(obj.format(), "2015440-02-13 12:57:81 GMT+01:00", "The date is weird...!")
     }
     
     func testEmptyArrayOfComponentsYieldsNilMoment() {
@@ -239,7 +240,8 @@ class MomentTests: XCTestCase {
     }
 
     func testFormatDates() {
-        let birthday = moment("1973-09-04")!
+        let timeZone = NSTimeZone(abbreviation: "GMT+01:00")!
+        let birthday = moment("1973-09-04", timeZone: timeZone)!
         let str = birthday.format(dateFormat: "EE QQQQ yyyy/dd/MMMM ZZZZ")
         XCTAssertEqual(str, "Tue 3rd quarter 1973/04/September GMT+01:00", "Complicated string")
 


### PR DESCRIPTION
Hi Adrian,

I fixed the test units that appeared to be making trouble. As far as I understood this correctly, the code was working fine. However, the assert expected a result in the "GMT+01" timezone.
I've also added Carthage support and adapted the README accordingly. In fact, it was already working. I've just checked to make sure :) 

Let me know what you think.
