### PR TITLE
Add startOf and endOf methods

### DIFF
--- a/SwiftMoment/SwiftMoment/Moment.swift
+++ b/SwiftMoment/SwiftMoment/Moment.swift
@@ -376,14 +376,39 @@ public struct Moment: Comparable {
         return Duration(value: interval)
     }
 
-    public func add(value: Double, _ unit: TimeUnit) -> Moment {
+    public func add(value: Int, _ unit: TimeUnit) -> Moment {
+        let components = NSDateComponents()
+        switch unit {
+        case .Years:
+            components.year = value
+        case .Quarters:
+            components.month = 3 * value
+        case .Months:
+            components.month = value
+        case .Days:
+            components.day = value
+        case .Hours:
+            components.hour = value
+        case .Minutes:
+            components.minute = value
+        case .Seconds:
+            components.second = value
+        }
+        let cal = NSCalendar.currentCalendar()
+        if let newDate = cal.dateByAddingComponents(components, toDate: date, options: nil) {
+          return Moment(date: newDate)
+        }
+        return self
+    }
+
+    public func add(value: NSTimeInterval, _ unit: TimeUnit) -> Moment {
         let seconds = convert(value, unit)
         let interval = NSTimeInterval(seconds)
         let newDate = date.dateByAddingTimeInterval(interval)
         return Moment(date: newDate)
     }
 
-    public func add(value: Double, _ unitName: String) -> Moment {
+    public func add(value: Int, _ unitName: String) -> Moment {
         if let unit = TimeUnit(rawValue: unitName) {
             return add(value, unit)
         }
@@ -394,14 +419,15 @@ public struct Moment: Comparable {
         return add(duration.interval, .Seconds)
     }
 
-    public func substract(value: Double, _ unit: TimeUnit) -> Moment {
-        let seconds = convert(value, unit) * -1
-        let interval = NSTimeInterval(seconds)
-        let newDate = date.dateByAddingTimeInterval(interval)
-        return Moment(date: newDate)
+    public func substract(value: NSTimeInterval, _ unit: TimeUnit) -> Moment {
+        return add(-value, unit)
     }
 
-    public func substract(value: Double, _ unitName: String) -> Moment {
+    public func substract(value: Int, _ unit: TimeUnit) -> Moment {
+        return add(-value, unit)
+    }
+
+    public func substract(value: Int, _ unitName: String) -> Moment {
         if let unit = TimeUnit(rawValue: unitName) {
             return substract(value, unit)
         }

--- a/SwiftMoment/SwiftMoment/Moment.swift
+++ b/SwiftMoment/SwiftMoment/Moment.swift
@@ -126,7 +126,6 @@ public func moment(params: [Int]
         }
         
         if let date = calendar.dateFromComponents(components) {
-            println(timeZone.abbreviation)
             return moment(date, timeZone: timeZone, locale: locale)
         }
     }

--- a/SwiftMoment/SwiftMoment/Moment.swift
+++ b/SwiftMoment/SwiftMoment/Moment.swift
@@ -445,6 +445,52 @@ public struct Moment: Comparable {
         return abs(delta.interval) < precision
     }
 
+    public func startOf(unit: TimeUnit) -> Moment {
+        let cal = NSCalendar.currentCalendar()
+        var newDate: NSDate?
+        let components = cal.components(.CalendarUnitYear | .CalendarUnitMonth
+            | .CalendarUnitDay | .CalendarUnitHour
+            | .CalendarUnitMinute | .CalendarUnitSecond, fromDate: date)
+        switch unit {
+        case .Seconds:
+            return self
+        case .Years:
+            components.month = 1
+            fallthrough
+        case .Quarters, .Months:
+            components.day = 1
+            fallthrough
+        case .Days:
+            components.hour = 0
+            fallthrough
+        case .Hours:
+            components.minute = 0
+            fallthrough
+        case .Minutes:
+            components.second = 0
+        }
+        newDate = cal.dateFromComponents(components)
+        return newDate == nil ? self : Moment(date: newDate!)
+    }
+
+    public func startOf(unitName: String) -> Moment {
+        if let unit = TimeUnit(rawValue: unitName) {
+            return startOf(unit)
+        }
+        return self
+    }
+
+    public func endOf(unit: TimeUnit) -> Moment {
+        return startOf(unit).add(1, unit).substract(1.seconds)
+    }
+
+    public func endOf(unitName: String) -> Moment {
+        if let unit = TimeUnit(rawValue: unitName) {
+            return endOf(unit)
+        }
+        return self
+    }
+
     // Private methods
 
     func convert(value: Double, _ unit: TimeUnit) -> Double {

--- a/SwiftMoment/SwiftMomentTests/MomentTests.swift
+++ b/SwiftMoment/SwiftMomentTests/MomentTests.swift
@@ -302,4 +302,85 @@ class MomentTests: XCTestCase {
         XCTAssertEqual(tag, "Sonntag", "Ach so!")
         XCTAssertEqual(monat, "März", "Ach so!")
     }
+
+    func testStartOfYear() {
+        var obj = moment([2015, 10, 19, 20, 45, 34])!.startOf("y")
+        XCTAssertEqual(obj.year, 2015, "The year should match")
+        XCTAssertEqual(obj.month, 1, "The month should match")
+        XCTAssertEqual(obj.day, 1, "The day should match")
+        XCTAssertEqual(obj.hour, 0, "The hour should match")
+        XCTAssertEqual(obj.minute, 0, "The minute should match")
+        XCTAssertEqual(obj.second, 0, "The second should match")
+    }
+
+    func testStartOfMonth() {
+        var obj = moment([2015, 10, 19, 20, 45, 34])!.startOf("M")
+        XCTAssertEqual(obj.year, 2015, "The year should match")
+        XCTAssertEqual(obj.month, 10, "The month should match")
+        XCTAssertEqual(obj.day, 1, "The day should match")
+        XCTAssertEqual(obj.hour, 0, "The hour should match")
+        XCTAssertEqual(obj.minute, 0, "The minute should match")
+        XCTAssertEqual(obj.second, 0, "The second should match")
+    }
+
+    func testStartOfDay() {
+        var obj = moment([2015, 10, 19, 20, 45, 34])!.startOf(.Days)
+        XCTAssertEqual(obj.year, 2015, "The year should match")
+        XCTAssertEqual(obj.month, 10, "The month should match")
+        XCTAssertEqual(obj.day, 19, "The day should match")
+        XCTAssertEqual(obj.hour, 0, "The hour should match")
+        XCTAssertEqual(obj.minute, 0, "The minute should match")
+        XCTAssertEqual(obj.second, 0, "The second should match")
+    }
+
+    func testStartOfHour() {
+        var obj = moment([2015, 10, 19, 20, 45, 34])!.startOf(.Hours)
+        XCTAssertEqual(obj.year, 2015, "The year should match")
+        XCTAssertEqual(obj.month, 10, "The month should match")
+        XCTAssertEqual(obj.day, 19, "The day should match")
+        XCTAssertEqual(obj.hour, 20, "The hour should match")
+        XCTAssertEqual(obj.minute, 0, "The minute should match")
+        XCTAssertEqual(obj.second, 0, "The second should match")
+    }
+
+    func testStartOfMinute() {
+        var obj = moment([2015, 10, 19, 20, 45, 34])!.startOf(.Minutes)
+        XCTAssertEqual(obj.year, 2015, "The year should match")
+        XCTAssertEqual(obj.month, 10, "The month should match")
+        XCTAssertEqual(obj.day, 19, "The day should match")
+        XCTAssertEqual(obj.hour, 20, "The day should match")
+        XCTAssertEqual(obj.minute, 45, "The minute should match")
+        XCTAssertEqual(obj.second, 0, "The second should match")
+    }
+
+    func testEndOfYear() {
+        var obj = moment([2015, 10, 19, 20, 45, 34])!.endOf(.Years)
+        XCTAssertEqual(obj.year, 2015, "The year should match")
+        XCTAssertEqual(obj.month, 12, "The month should match")
+        XCTAssertEqual(obj.day, 31, "The day should match")
+        XCTAssertEqual(obj.hour, 23, "The hour should match")
+        XCTAssertEqual(obj.minute, 59, "The minute should match")
+        XCTAssertEqual(obj.second, 59, "The second should match")
+    }
+
+    func testEndOfMonth() {
+        var obj = moment([2015, 01, 19, 20, 45, 34])!.endOf(.Months)
+        XCTAssertEqual(obj.year, 2015, "The year should match")
+        XCTAssertEqual(obj.month, 01, "The month should match")
+        XCTAssertEqual(obj.day, 31, "The day should match")
+        XCTAssertEqual(obj.hour, 23, "The hour should match")
+        XCTAssertEqual(obj.minute, 59, "The minute should match")
+        XCTAssertEqual(obj.second, 59, "The second should match")
+    }
+
+    func testEndOfDay() {
+        var obj = moment([2015, 10, 19, 20, 45, 34])!.endOf("d")
+        XCTAssertEqual(obj.year, 2015, "The year should match")
+        XCTAssertEqual(obj.month, 10, "The month should match")
+        XCTAssertEqual(obj.day, 19, "The day should match")
+        XCTAssertEqual(obj.hour, 23, "The day should match")
+        XCTAssertEqual(obj.minute, 59, "The minute should match")
+        XCTAssertEqual(obj.second, 59, "The second should match")
+    }
+
 }

--- a/SwiftMoment/SwiftMomentTests/MomentTests.swift
+++ b/SwiftMoment/SwiftMomentTests/MomentTests.swift
@@ -170,19 +170,34 @@ class MomentTests: XCTestCase {
         XCTAssertEqual(copy, today, "Equality is commutative")
     }
 
-    func testCanUseDifferentSyntaxesToAddAndSubstract() {
-        let now = moment()
-        let one = now.add(5.hours).substract(45.years)
-        let two = now.add(5, .Hours).substract(45, .Years)
-        let three = now.add(5, "H").substract(45, "y")
-        let four = now + 5.hours - 45.years
+    func testDifferentSyntaxesToAddAndSubstract() {
+        // month durations always add 30 days
+        var one = moment([2015, 7, 29, 0, 0])!
+        var exactly_thirty_days = moment([2015, 8, 28, 0, 0])!
+        XCTAssertEqual(exactly_thirty_days, one.add(1.months), "Duration adds exactly 30 days")
+        XCTAssertEqual(30.days, exactly_thirty_days - one, "exactly_thirty_days is a difference of 30 days")
+        XCTAssertEqual(one, exactly_thirty_days.substract(1.months), "Subtracting back to one is okay")
 
-        XCTAssertEqual(one, two, "All the different operations yield the same results")
-        XCTAssertEqual(one, three, "All the different operations yield the same results")
-        XCTAssertEqual(one, four, "All the different operations yield the same results")
-        XCTAssertEqual(two, three, "All the different operations yield the same results")
-        XCTAssertEqual(two, four, "All the different operations yield the same results")
-        XCTAssertEqual(three, four, "All the different operations yield the same results")
+        // adding by a TimeUnit.Month jumps 1 month (not necessarily 30 days)
+        var two = moment([2015, 7, 29, 0, 0])!
+        var exactly_one_month = moment([2015, 8, 29, 0, 0])!
+        XCTAssertEqual(exactly_one_month, two.add(1, .Months), "Time unit adds exactly one month")
+        XCTAssertEqual(31.days, exactly_one_month - two, "exactly_on_month is a difference of 31 days")
+        XCTAssertEqual(two, exactly_one_month.substract(1, .Months), "Subtracting back to two is okay")
+
+
+        // use Duration to always add/subtract 365 days for years,
+        // otherwise, use TimeUnit.Year
+        let all_years_365 = moment().add(5.years)
+        let consider_leap_years = moment().add(5, .Years)
+        XCTAssertNotEqual(all_years_365, consider_leap_years, "5.years is not equal to 5, .Years")
+
+        // Duration vs TimeUnit does not matter for days, hours, minutes, seconds
+        let today = moment()
+        let first = moment(today).add(50.days)
+        let second = moment(today).add(50, .Days)
+        XCTAssertEqual(first, second, "Syntax does not matter when adding days")
+        XCTAssertEqual(first.substract(40, .Days), second.substract(40.days), "Syntax does not matter when subtracting days")
     }
 
     func testAdditionAndSubstractionAreInverse() {


### PR DESCRIPTION
In order to cleanly implement these methods I added support for adding and subtracting moments by real months and years because we quickly run into issues if we assume every month is 30 days and year 365. See e9a9d01 for more details.
