### PR TITLE
Parse second fractions

### DIFF
--- a/SwiftMoment/SwiftMoment/Moment.swift
+++ b/SwiftMoment/SwiftMoment/Moment.swift
@@ -50,6 +50,7 @@ public func moment(stringDate: String
     let formats = [
         isoFormat,
         "yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'",
+        "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'SSS'Z'",
         "yyyy-MM-dd",
         "h:mm:ss A",
         "h:mm A",


### PR DESCRIPTION
Add format pattern for date strings (used in mongodb) like:
2015-08-31T23:12:31.987Z
