### PR TITLE
Fixed default date format in format methods.

### DIFF
--- a/SwiftMoment/SwiftMoment/Moment.swift
+++ b/SwiftMoment/SwiftMoment/Moment.swift
@@ -366,7 +366,7 @@ public struct Moment: Comparable {
         return nil
     }
 
-    public func format(dateFormat: String = "yyyy-MM-dd HH:mm:SS ZZZZ") -> String {
+    public func format(dateFormat: String = "yyyy-MM-dd HH:mm:ss ZZZZ") -> String {
         let formatter = NSDateFormatter()
         formatter.dateFormat = dateFormat
         formatter.timeZone = timeZone

--- a/SwiftMoment/SwiftMomentTests/MomentTests.swift
+++ b/SwiftMoment/SwiftMomentTests/MomentTests.swift
@@ -110,7 +110,7 @@ class MomentTests: XCTestCase {
     func testCanCreateWeirdDateFromComponents() {
         let timeZone = NSTimeZone(abbreviation: "GMT+01")!
         let obj = moment([-2015445, 76, -46, 876, 234565, -999], timeZone: timeZone)!
-        XCTAssertEqual(obj.format(), "2015440-02-13 12:57:81 GMT+01:00", "The date is weird...!")
+        XCTAssertEqual(obj.format(), "2015440-02-13 12:57:11 GMT+01:00", "The date is weird...!")
     }
     
     func testEmptyArrayOfComponentsYieldsNilMoment() {


### PR DESCRIPTION
`SS` is milliseconds. and, `ss` is seconds.
