### PR TITLE
fix formatter's locale

### DIFF
--- a/SwiftMoment/SwiftMoment/Moment.swift
+++ b/SwiftMoment/SwiftMoment/Moment.swift
@@ -40,8 +40,10 @@ parsed by the function, the Optional wraps a nil value.
 public func moment(stringDate: String
     , timeZone: NSTimeZone = NSTimeZone.defaultTimeZone()
     , locale: NSLocale = NSLocale.autoupdatingCurrentLocale()) -> Moment? {
+
     let formatter = NSDateFormatter()
     formatter.timeZone = timeZone
+    formatter.locale = locale
     let isoFormat = "yyyy-MM-ddTHH:mm:ssZ"
 
     // The contents of the array below are borrowed
@@ -86,6 +88,7 @@ public func moment(stringDate: String
     let formatter = NSDateFormatter()
     formatter.dateFormat = dateFormat
     formatter.timeZone = timeZone
+    formatter.locale = locale
     if let date = formatter.dateFromString(stringDate) {
         return Moment(date: date, timeZone: timeZone, locale: locale)
     }

--- a/SwiftMoment/SwiftMomentTests/MomentTests.swift
+++ b/SwiftMoment/SwiftMomentTests/MomentTests.swift
@@ -259,6 +259,20 @@ class MomentTests: XCTestCase {
         XCTAssertEqual(standard, "1973-09-04 00:00:00 GMT+01:00", "Standard output")
     }
 
+    func testFormatDatesWithLocale() {
+        let ad = NSLocale(localeIdentifier: "en_US_POSIX")
+        let defaultFormatAd = moment("2015-09-04", locale: ad)!
+        let giveFormatAd    = moment("2015", dateFormat: "yyyy", locale: ad)!
+        XCTAssertEqual(defaultFormatAd.year, 2015, "AD2015")
+        XCTAssertEqual(giveFormatAd.year,    2015, "AD2015")
+
+        let japanese = NSLocale(localeIdentifier: "ja_JP@calendar=japanese")
+        let defaultFormatJapanese = moment("0027-09-04", locale: japanese)!
+        let giveFormatJapanese    = moment("0027", dateFormat: "yyyy", locale: japanese)!
+        XCTAssertEqual(defaultFormatJapanese.year, 2015, "AD2015 == 27 Heisei period")
+        XCTAssertEqual(giveFormatJapanese.year,    2015, "AD2015 == 27 Heisei period")
+    }
+
     func testFutureMoment() {
         let duration = future() - moment()
         XCTAssertGreaterThan(duration.years, 1000, "The future is really far away")


### PR DESCRIPTION
[These methods](https://github.com/akosma/SwiftMoment/blob/19ab920430a1d5820bbda9a02912aa5d959cbcb7/SwiftMoment/SwiftMoment/Moment.swift#L40-L93) receive NSLocale, but they don't give NSLocale to the formatter. This cause dependency on device's locale settings. For example, when a device's locale was set to Japanese Heisei period, '2015' is parsed to 27 by format 'yyyy'.
I fixed it.
