### PR TITLE
Support OS X

### DIFF
--- a/SwiftMoment/SwiftMoment.xcodeproj/project.pbxproj
+++ b/SwiftMoment/SwiftMoment.xcodeproj/project.pbxproj
@@ -16,6 +16,9 @@
 		3AB0FB891A6D160F006449DB /* Moment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB0FB881A6D160F006449DB /* Moment.swift */; };
 		3AB0FB8B1A6D1629006449DB /* TimeUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB0FB8A1A6D1629006449DB /* TimeUnit.swift */; };
 		3AB0FB8D1A6D1644006449DB /* Duration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB0FB8C1A6D1644006449DB /* Duration.swift */; };
+		E2532BF11C358B4E00392471 /* SwiftMoment.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2F6254B1C357BC00057AE1D /* SwiftMoment.framework */; };
+		E2532BF71C358BC000392471 /* MomentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB0FB7E1A6D15F8006449DB /* MomentTests.swift */; };
+		E2532BF81C358BC000392471 /* DurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6429C71A6D345500B10310 /* DurationTests.swift */; };
 		E2F6253F1C357BC00057AE1D /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6429C51A6D33FA00B10310 /* Extensions.swift */; };
 		E2F625401C357BC00057AE1D /* Duration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB0FB8C1A6D1644006449DB /* Duration.swift */; };
 		E2F625411C357BC00057AE1D /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6429C31A6D2C8700B10310 /* Operators.swift */; };
@@ -31,6 +34,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 3AB0FB6B1A6D15F8006449DB;
 			remoteInfo = SwiftMoment;
+		};
+		E2532BF21C358B4E00392471 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3AB0FB631A6D15F8006449DB /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E2F6253D1C357BC00057AE1D;
+			remoteInfo = SwiftMomentOSX;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -48,6 +58,8 @@
 		3AB0FB881A6D160F006449DB /* Moment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Moment.swift; sourceTree = "<group>"; };
 		3AB0FB8A1A6D1629006449DB /* TimeUnit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeUnit.swift; sourceTree = "<group>"; };
 		3AB0FB8C1A6D1644006449DB /* Duration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Duration.swift; sourceTree = "<group>"; };
+		E2532BEC1C358B4E00392471 /* SwiftMomentOSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftMomentOSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		E2532BF91C358BF000392471 /* InfoOSX.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = InfoOSX.plist; sourceTree = "<group>"; };
 		E2F6254B1C357BC00057AE1D /* SwiftMoment.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftMoment.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E2F6254D1C357CEB0057AE1D /* InfoOSX.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = InfoOSX.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -65,6 +77,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				3AB0FB781A6D15F8006449DB /* SwiftMoment.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E2532BE91C358B4E00392471 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E2532BF11C358B4E00392471 /* SwiftMoment.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -94,6 +114,7 @@
 				3AB0FB6C1A6D15F8006449DB /* SwiftMoment.framework */,
 				3AB0FB771A6D15F8006449DB /* SwiftMomentTests.xctest */,
 				E2F6254B1C357BC00057AE1D /* SwiftMoment.framework */,
+				E2532BEC1C358B4E00392471 /* SwiftMomentOSXTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -134,6 +155,7 @@
 		3AB0FB7C1A6D15F8006449DB /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				E2532BF91C358BF000392471 /* InfoOSX.plist */,
 				3AB0FB7D1A6D15F8006449DB /* Info.plist */,
 			);
 			name = "Supporting Files";
@@ -197,6 +219,24 @@
 			productReference = 3AB0FB771A6D15F8006449DB /* SwiftMomentTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		E2532BEB1C358B4E00392471 /* SwiftMomentOSXTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E2532BF61C358B4E00392471 /* Build configuration list for PBXNativeTarget "SwiftMomentOSXTests" */;
+			buildPhases = (
+				E2532BE81C358B4E00392471 /* Sources */,
+				E2532BE91C358B4E00392471 /* Frameworks */,
+				E2532BEA1C358B4E00392471 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				E2532BF31C358B4E00392471 /* PBXTargetDependency */,
+			);
+			name = SwiftMomentOSXTests;
+			productName = SwiftMomentOSXTests;
+			productReference = E2532BEC1C358B4E00392471 /* SwiftMomentOSXTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		E2F6253D1C357BC00057AE1D /* SwiftMomentOSX */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = E2F625481C357BC00057AE1D /* Build configuration list for PBXNativeTarget "SwiftMomentOSX" */;
@@ -222,7 +262,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftMigration = 0700;
-				LastSwiftUpdateCheck = 0700;
+				LastSwiftUpdateCheck = 0720;
 				LastUpgradeCheck = 0610;
 				ORGANIZATIONNAME = "Adrian Kosmaczewski";
 				TargetAttributes = {
@@ -231,6 +271,9 @@
 					};
 					3AB0FB761A6D15F8006449DB = {
 						CreatedOnToolsVersion = 6.1.1;
+					};
+					E2532BEB1C358B4E00392471 = {
+						CreatedOnToolsVersion = 7.2;
 					};
 				};
 			};
@@ -249,6 +292,7 @@
 				3AB0FB6B1A6D15F8006449DB /* SwiftMoment */,
 				3AB0FB761A6D15F8006449DB /* SwiftMomentTests */,
 				E2F6253D1C357BC00057AE1D /* SwiftMomentOSX */,
+				E2532BEB1C358B4E00392471 /* SwiftMomentOSXTests */,
 			);
 		};
 /* End PBXProject section */
@@ -262,6 +306,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		3AB0FB751A6D15F8006449DB /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E2532BEA1C358B4E00392471 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -299,6 +350,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E2532BE81C358B4E00392471 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E2532BF71C358BC000392471 /* MomentTests.swift in Sources */,
+				E2532BF81C358BC000392471 /* DurationTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E2F6253E1C357BC00057AE1D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -318,6 +378,11 @@
 			isa = PBXTargetDependency;
 			target = 3AB0FB6B1A6D15F8006449DB /* SwiftMoment */;
 			targetProxy = 3AB0FB791A6D15F8006449DB /* PBXContainerItemProxy */;
+		};
+		E2532BF31C358B4E00392471 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E2F6253D1C357BC00057AE1D /* SwiftMomentOSX */;
+			targetProxy = E2532BF21C358B4E00392471 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -474,6 +539,40 @@
 			};
 			name = Release;
 		};
+		E2532BF41C358B4E00392471 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = SwiftMomentTests/InfoOSX.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = com.akosma.SwiftMomentOSXTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		E2532BF51C358B4E00392471 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = SwiftMomentTests/InfoOSX.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = com.akosma.SwiftMomentOSXTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
 		E2F625491C357BC00057AE1D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -544,6 +643,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		E2532BF61C358B4E00392471 /* Build configuration list for PBXNativeTarget "SwiftMomentOSXTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E2532BF41C358B4E00392471 /* Debug */,
+				E2532BF51C358B4E00392471 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 		E2F625481C357BC00057AE1D /* Build configuration list for PBXNativeTarget "SwiftMomentOSX" */ = {
 			isa = XCConfigurationList;

--- a/SwiftMoment/SwiftMoment.xcodeproj/project.pbxproj
+++ b/SwiftMoment/SwiftMoment.xcodeproj/project.pbxproj
@@ -16,6 +16,12 @@
 		3AB0FB891A6D160F006449DB /* Moment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB0FB881A6D160F006449DB /* Moment.swift */; };
 		3AB0FB8B1A6D1629006449DB /* TimeUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB0FB8A1A6D1629006449DB /* TimeUnit.swift */; };
 		3AB0FB8D1A6D1644006449DB /* Duration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB0FB8C1A6D1644006449DB /* Duration.swift */; };
+		E2F6253F1C357BC00057AE1D /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6429C51A6D33FA00B10310 /* Extensions.swift */; };
+		E2F625401C357BC00057AE1D /* Duration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB0FB8C1A6D1644006449DB /* Duration.swift */; };
+		E2F625411C357BC00057AE1D /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6429C31A6D2C8700B10310 /* Operators.swift */; };
+		E2F625421C357BC00057AE1D /* TimeUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB0FB8A1A6D1629006449DB /* TimeUnit.swift */; };
+		E2F625431C357BC00057AE1D /* Moment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB0FB881A6D160F006449DB /* Moment.swift */; };
+		E2F625461C357BC00057AE1D /* SwiftMoment.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB0FB711A6D15F8006449DB /* SwiftMoment.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -42,6 +48,8 @@
 		3AB0FB881A6D160F006449DB /* Moment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Moment.swift; sourceTree = "<group>"; };
 		3AB0FB8A1A6D1629006449DB /* TimeUnit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeUnit.swift; sourceTree = "<group>"; };
 		3AB0FB8C1A6D1644006449DB /* Duration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Duration.swift; sourceTree = "<group>"; };
+		E2F6254B1C357BC00057AE1D /* SwiftMomentOSX.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftMomentOSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E2F6254D1C357CEB0057AE1D /* InfoOSX.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = InfoOSX.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -57,6 +65,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				3AB0FB781A6D15F8006449DB /* SwiftMoment.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E2F625441C357BC00057AE1D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -78,6 +93,7 @@
 			children = (
 				3AB0FB6C1A6D15F8006449DB /* SwiftMoment.framework */,
 				3AB0FB771A6D15F8006449DB /* SwiftMomentTests.xctest */,
+				E2F6254B1C357BC00057AE1D /* SwiftMomentOSX.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -99,6 +115,7 @@
 		3AB0FB6F1A6D15F8006449DB /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				E2F6254D1C357CEB0057AE1D /* InfoOSX.plist */,
 				3AB0FB701A6D15F8006449DB /* Info.plist */,
 			);
 			name = "Supporting Files";
@@ -130,6 +147,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				3AB0FB721A6D15F8006449DB /* SwiftMoment.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E2F625451C357BC00057AE1D /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E2F625461C357BC00057AE1D /* SwiftMoment.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -172,6 +197,24 @@
 			productReference = 3AB0FB771A6D15F8006449DB /* SwiftMomentTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		E2F6253D1C357BC00057AE1D /* SwiftMomentOSX */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E2F625481C357BC00057AE1D /* Build configuration list for PBXNativeTarget "SwiftMomentOSX" */;
+			buildPhases = (
+				E2F6253E1C357BC00057AE1D /* Sources */,
+				E2F625441C357BC00057AE1D /* Frameworks */,
+				E2F625451C357BC00057AE1D /* Headers */,
+				E2F625471C357BC00057AE1D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwiftMomentOSX;
+			productName = SwiftMoment;
+			productReference = E2F6254B1C357BC00057AE1D /* SwiftMomentOSX.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -205,6 +248,7 @@
 			targets = (
 				3AB0FB6B1A6D15F8006449DB /* SwiftMoment */,
 				3AB0FB761A6D15F8006449DB /* SwiftMomentTests */,
+				E2F6253D1C357BC00057AE1D /* SwiftMomentOSX */,
 			);
 		};
 /* End PBXProject section */
@@ -218,6 +262,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		3AB0FB751A6D15F8006449DB /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E2F625471C357BC00057AE1D /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -245,6 +296,18 @@
 			files = (
 				3AB0FB7F1A6D15F8006449DB /* MomentTests.swift in Sources */,
 				3A6429C81A6D345500B10310 /* DurationTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E2F6253E1C357BC00057AE1D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E2F6253F1C357BC00057AE1D /* Extensions.swift in Sources */,
+				E2F625401C357BC00057AE1D /* Duration.swift in Sources */,
+				E2F625411C357BC00057AE1D /* Operators.swift in Sources */,
+				E2F625421C357BC00057AE1D /* TimeUnit.swift in Sources */,
+				E2F625431C357BC00057AE1D /* Moment.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -411,6 +474,45 @@
 			};
 			name = Release;
 		};
+		E2F625491C357BC00057AE1D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = SwiftMoment/InfoOSX.plist;
+				INSTALL_PATH = "@executable_path/../Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		E2F6254A1C357BC00057AE1D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = SwiftMoment/InfoOSX.plist;
+				INSTALL_PATH = "@executable_path/../Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -437,6 +539,15 @@
 			buildConfigurations = (
 				3AB0FB861A6D15F8006449DB /* Debug */,
 				3AB0FB871A6D15F8006449DB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E2F625481C357BC00057AE1D /* Build configuration list for PBXNativeTarget "SwiftMomentOSX" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E2F625491C357BC00057AE1D /* Debug */,
+				E2F6254A1C357BC00057AE1D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/SwiftMoment/SwiftMoment.xcodeproj/project.pbxproj
+++ b/SwiftMoment/SwiftMoment.xcodeproj/project.pbxproj
@@ -48,7 +48,7 @@
 		3AB0FB881A6D160F006449DB /* Moment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Moment.swift; sourceTree = "<group>"; };
 		3AB0FB8A1A6D1629006449DB /* TimeUnit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeUnit.swift; sourceTree = "<group>"; };
 		3AB0FB8C1A6D1644006449DB /* Duration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Duration.swift; sourceTree = "<group>"; };
-		E2F6254B1C357BC00057AE1D /* SwiftMomentOSX.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftMomentOSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E2F6254B1C357BC00057AE1D /* SwiftMoment.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftMoment.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E2F6254D1C357CEB0057AE1D /* InfoOSX.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = InfoOSX.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -93,7 +93,7 @@
 			children = (
 				3AB0FB6C1A6D15F8006449DB /* SwiftMoment.framework */,
 				3AB0FB771A6D15F8006449DB /* SwiftMomentTests.xctest */,
-				E2F6254B1C357BC00057AE1D /* SwiftMomentOSX.framework */,
+				E2F6254B1C357BC00057AE1D /* SwiftMoment.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -212,7 +212,7 @@
 			);
 			name = SwiftMomentOSX;
 			productName = SwiftMoment;
-			productReference = E2F6254B1C357BC00057AE1D /* SwiftMomentOSX.framework */;
+			productReference = E2F6254B1C357BC00057AE1D /* SwiftMoment.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -487,7 +487,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = SwiftMoment;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -508,7 +508,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = SwiftMoment;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/SwiftMoment/SwiftMoment.xcodeproj/project.pbxproj
+++ b/SwiftMoment/SwiftMoment.xcodeproj/project.pbxproj
@@ -486,6 +486,7 @@
 				INSTALL_PATH = "@executable_path/../Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -506,6 +507,7 @@
 				INSTALL_PATH = "@executable_path/../Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;

--- a/SwiftMoment/SwiftMoment.xcodeproj/xcshareddata/xcschemes/SwiftMomentOSX.xcscheme
+++ b/SwiftMoment/SwiftMoment.xcodeproj/xcshareddata/xcschemes/SwiftMomentOSX.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "E2F6253D1C357BC00057AE1D"
-               BuildableName = "SwiftMomentOSX.framework"
+               BuildableName = "SwiftMoment.framework"
                BlueprintName = "SwiftMomentOSX"
                ReferencedContainer = "container:SwiftMoment.xcodeproj">
             </BuildableReference>
@@ -28,7 +28,26 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E2532BEB1C358B4E00392471"
+               BuildableName = "SwiftMomentOSXTests.xctest"
+               BlueprintName = "SwiftMomentOSXTests"
+               ReferencedContainer = "container:SwiftMoment.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E2F6253D1C357BC00057AE1D"
+            BuildableName = "SwiftMoment.framework"
+            BlueprintName = "SwiftMomentOSX"
+            ReferencedContainer = "container:SwiftMoment.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -46,7 +65,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "E2F6253D1C357BC00057AE1D"
-            BuildableName = "SwiftMomentOSX.framework"
+            BuildableName = "SwiftMoment.framework"
             BlueprintName = "SwiftMomentOSX"
             ReferencedContainer = "container:SwiftMoment.xcodeproj">
          </BuildableReference>
@@ -64,7 +83,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "E2F6253D1C357BC00057AE1D"
-            BuildableName = "SwiftMomentOSX.framework"
+            BuildableName = "SwiftMoment.framework"
             BlueprintName = "SwiftMomentOSX"
             ReferencedContainer = "container:SwiftMoment.xcodeproj">
          </BuildableReference>

--- a/SwiftMoment/SwiftMoment.xcodeproj/xcshareddata/xcschemes/SwiftMomentOSX.xcscheme
+++ b/SwiftMoment/SwiftMoment.xcodeproj/xcshareddata/xcschemes/SwiftMomentOSX.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E2F6253D1C357BC00057AE1D"
+               BuildableName = "SwiftMomentOSX.framework"
+               BlueprintName = "SwiftMomentOSX"
+               ReferencedContainer = "container:SwiftMoment.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E2F6253D1C357BC00057AE1D"
+            BuildableName = "SwiftMomentOSX.framework"
+            BlueprintName = "SwiftMomentOSX"
+            ReferencedContainer = "container:SwiftMoment.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E2F6253D1C357BC00057AE1D"
+            BuildableName = "SwiftMomentOSX.framework"
+            BlueprintName = "SwiftMomentOSX"
+            ReferencedContainer = "container:SwiftMoment.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SwiftMoment/SwiftMoment/InfoOSX.plist
+++ b/SwiftMoment/SwiftMoment/InfoOSX.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.akosma.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/SwiftMoment/SwiftMoment/SwiftMoment.h
+++ b/SwiftMoment/SwiftMoment/SwiftMoment.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Adrian Kosmaczewski. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 
 //! Project version number for SwiftMoment.
 FOUNDATION_EXPORT double SwiftMomentVersionNumber;

--- a/SwiftMoment/SwiftMomentTests/DurationTests.swift
+++ b/SwiftMoment/SwiftMomentTests/DurationTests.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Adrian Kosmaczewski. All rights reserved.
 //
 
-import UIKit
+import Foundation
 import XCTest
 import SwiftMoment
 

--- a/SwiftMoment/SwiftMomentTests/InfoOSX.plist
+++ b/SwiftMoment/SwiftMomentTests/InfoOSX.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/SwiftMoment/SwiftMomentTests/MomentTests.swift
+++ b/SwiftMoment/SwiftMomentTests/MomentTests.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Adrian Kosmaczewski. All rights reserved.
 //
 
-import UIKit
+import Foundation
 import XCTest
 import SwiftMoment
 


### PR DESCRIPTION
Added an OS X Target and Test Target

Supports OS X 10.10 and links to the original tests
Tests Pass!

To use in your OS X Project:
http://stackoverflow.com/questions/24993752/os-x-framework-library-not-loaded-image-not-found

Including The Framework
Drag the created .framework file into the Xcode Project, be sure to tick 'Copy Files to Directory'
In the containing applications target, add a new 'Copy File Build Phase'
Set the 'Destination' to 'Frameworks'
Drag in the created .framework
