### PR TITLE
Made the date, timeZone and locale members publicly readable

### DIFF
--- a/SwiftMoment/SwiftMoment/Moment.swift
+++ b/SwiftMoment/SwiftMoment/Moment.swift
@@ -232,9 +232,9 @@ public func minimum(moments: Moment...) -> Moment? {
  call moment() with one of the supported input types.
 */
 public struct Moment: Comparable {
-    let date: NSDate
-    let timeZone: NSTimeZone
-    let locale: NSLocale
+    public let date: NSDate
+    public let timeZone: NSTimeZone
+    public let locale: NSLocale
 
     init(date: NSDate = NSDate()
         , timeZone: NSTimeZone = NSTimeZone.defaultTimeZone()

--- a/SwiftMoment/SwiftMomentTests/MomentTests.swift
+++ b/SwiftMoment/SwiftMomentTests/MomentTests.swift
@@ -401,4 +401,22 @@ class MomentTests: XCTestCase {
         XCTAssertEqual(jst.epoch(), gmt.epoch(), "The JST epoch should match GMT epoch")
     }
 
+	func testPublicDate() {
+		let date = NSDate()
+		let now = moment(date)
+		XCTAssertEqual(now.date, date, "The moment's date should be publicly readable")
+		XCTAssertEqual(now.timeZone, NSTimeZone.defaultTimeZone(), "The moment's timeZone should be publicly readable and default to the current timezone")
+	}
+	
+	func testPublicTimeZone() {
+		let date = NSDate()
+		let now = moment(date)
+		XCTAssertEqual(now.timeZone, NSTimeZone.defaultTimeZone(), "The moment's timeZone should be publicly readable and default to the current timezone")
+	}
+
+	func testPublicLocale() {
+		let date = NSDate()
+		let now = moment(date)
+		XCTAssertEqual(now.locale, NSLocale.currentLocale(), "The moment's locale should be publicly readable and default to the current locale")
+	}
 }


### PR DESCRIPTION
So that we can extract the date after making computations (i.e. adding days, etc)
