### PR TITLE
Fix ISO 8601 format

### DIFF
--- a/SwiftMoment/SwiftMoment/Moment.swift
+++ b/SwiftMoment/SwiftMoment/Moment.swift
@@ -44,7 +44,7 @@ public func moment(stringDate: String
     let formatter = NSDateFormatter()
     formatter.timeZone = timeZone
     formatter.locale = locale
-    let isoFormat = "yyyy-MM-ddTHH:mm:ssZ"
+    let isoFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
 
     // The contents of the array below are borrowed
     // and adapted from the source code of Moment.js


### PR DESCRIPTION
The five “Z”s vs just the one doesn’t seem to matter anymore, but [apparently it used to](http://stackoverflow.com/questions/16254575/how-do-i-get-iso-8601-date-in-ios)? The T definitely needed quotes, though.
