### PR TITLE
Fixed Issue with fromNow() and cocoapods

### DIFF
--- a/SwiftMoment/SwiftMoment/MomentFromNow.swift
+++ b/SwiftMoment/SwiftMoment/MomentFromNow.swift
@@ -8,6 +8,9 @@
 
 import Foundation
 
+// needed to dynamically select the bundle below
+class MomentBundle: NSObject { }
+
 extension Moment {
     public func fromNow() -> String {
       let timeDiffDuration = moment(NSDate()).intervalSince(self)
@@ -85,7 +88,10 @@ extension Moment {
 
     private func NSDateTimeAgoLocalizedStrings(key: String) -> String {
       // get framework bundle
-      let bundleIdentifier = "com.akosma.SwiftMoment"
+      guard let bundleIdentifier = NSBundle(forClass: MomentBundle.self).bundleIdentifier  else {
+        return ""
+      }
+      
       guard let frameworkBundle = NSBundle(identifier: bundleIdentifier) else {
         return ""
       }


### PR DESCRIPTION
https://github.com/akosma/SwiftMoment/issues/56

Made the Identifier dynamic by adding a proxy class MomentBundle
