### PR TITLE
Maintain same timezone after add, subtract, startOf and endOf

### DIFF
--- a/SwiftMoment/SwiftMoment/Moment.swift
+++ b/SwiftMoment/SwiftMoment/Moment.swift
@@ -471,6 +471,8 @@ public struct Moment: Comparable {
 
     public func startOf(unit: TimeUnit) -> Moment {
         let cal = NSCalendar.currentCalendar()
+        cal.locale = locale
+        cal.timeZone = timeZone
         var newDate: NSDate?
         let components = cal.components([.Year, .Month, .Weekday, .Day, .Hour, .Minute, .Second],
                                         fromDate: date)

--- a/SwiftMoment/SwiftMoment/Moment.swift
+++ b/SwiftMoment/SwiftMoment/Moment.swift
@@ -420,7 +420,7 @@ public struct Moment: Comparable {
         cal.locale = locale
         if let newDate = cal.dateByAddingComponents(components, toDate: date,
                                                     options: NSCalendarOptions.init(rawValue: 0)) {
-          return Moment(date: newDate)
+          return Moment(date: newDate, timeZone: timeZone)
         }
         return self
     }
@@ -429,7 +429,7 @@ public struct Moment: Comparable {
         let seconds = convert(value, unit)
         let interval = NSTimeInterval(seconds)
         let newDate = date.dateByAddingTimeInterval(interval)
-        return Moment(date: newDate)
+        return Moment(date: newDate, timeZone: timeZone)
     }
 
     public func add(value: Int, _ unitName: String) -> Moment {
@@ -497,7 +497,7 @@ public struct Moment: Comparable {
             components.second = 0
         }
         newDate = cal.dateFromComponents(components)
-        return newDate == nil ? self : Moment(date: newDate!)
+        return newDate == nil ? self : Moment(date: newDate!, timeZone: timeZone)
     }
 
     public func startOf(unitName: String) -> Moment {

--- a/SwiftMoment/SwiftMomentTests/MomentTests.swift
+++ b/SwiftMoment/SwiftMomentTests/MomentTests.swift
@@ -458,12 +458,36 @@ class MomentTests: XCTestCase {
 		XCTAssertEqual(now.locale, NSLocale.currentLocale(), expectedString)
 	}
 
-  func testAddingInt() {
-    // This is to verify that issue #48 is corrected
-    // https://github.com/akosma/SwiftMoment/issues/48
-    let problem = moment("2016-07-01")!
-    let result = problem.add(1, .Months)
-    let expected = moment("2016-08-01")!
-    XCTAssertEqual(result, expected)
-  }
+    func testAddingInt() {
+        // This is to verify that issue #48 is corrected
+        // https://github.com/akosma/SwiftMoment/issues/48
+        let problem = moment("2016-07-01")!
+        let result = problem.add(1, .Months)
+        let expected = moment("2016-08-01")!
+        XCTAssertEqual(result, expected)
+    }
+
+    func testTimeZoneChangeAdd() {
+        let now = moment(NSTimeZone(abbreviation: "UTC")!)
+        let tomorrow = now.add(1, .Days)
+        XCTAssertEqual(now.timeZone, tomorrow.timeZone)
+    }
+
+    func testTimeZoneChangeSubtract() {
+        let now = moment(NSTimeZone(abbreviation: "UTC")!)
+        let yesterday = now.subtract(1, .Days)
+        XCTAssertEqual(now.timeZone, yesterday.timeZone)
+    }
+
+    func testTimeZoneChangeStartOf() {
+        let now = moment(NSTimeZone(abbreviation: "UTC")!)
+        let startOfDay = now.startOf(.Days)
+        XCTAssertEqual(now.timeZone, startOfDay.timeZone)
+    }
+
+    func testTimeZoneChangeEndOf() {
+        let now = moment(NSTimeZone(abbreviation: "UTC")!)
+        let endOfDay = now.endOf(.Days)
+        XCTAssertEqual(now.timeZone, endOfDay.timeZone)
+    }
 }

--- a/SwiftMoment/SwiftMomentTests/MomentTests.swift
+++ b/SwiftMoment/SwiftMomentTests/MomentTests.swift
@@ -490,4 +490,15 @@ class MomentTests: XCTestCase {
         let endOfDay = now.endOf(.Days)
         XCTAssertEqual(now.timeZone, endOfDay.timeZone)
     }
+
+    func testTimeZoneStartOfDay() {
+        let cet = NSTimeZone(abbreviation: "CET")!
+        let edt = NSTimeZone(abbreviation: "EDT")!
+        let nowCet = moment(cet)
+        let nowEdt = moment(edt)
+        let startOfDayCet = nowCet.startOf(.Days)
+        let startOfDayEdt = nowEdt.startOf(.Days)
+        XCTAssertEqual(startOfDayCet.hour, 0)
+        XCTAssertEqual(startOfDayEdt.hour, 0)
+    }
 }


### PR DESCRIPTION
When you pass a specific timezone to a moment instance and then call add, subtract, startOf or endOf, the resulting moment instance will have the default timezone and not the one set in the first instance.
I fixed the issue in this PR and added few tests as well.
