### PR TITLE
Speed up calendar access by using a cache

### DIFF
--- a/SwiftMoment.podspec
+++ b/SwiftMoment.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "SwiftMoment"
-  s.version      = "0.7"
+  s.version      = "0.8"
   s.summary      = "A time and calendar manipulation library for iOS / macOS / tvOS / watchOS written in Swift"
   s.description  = <<-DESC
                     This framework is inspired by Moment.js. Its objectives are the following:

--- a/SwiftMoment/SwiftMoment.xcodeproj/project.pbxproj
+++ b/SwiftMoment/SwiftMoment.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		3AFB8ABE1DAE395000356653 /* LazyBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AFB8AB91DAE395000356653 /* LazyBox.swift */; };
 		3AFB8ABF1DAE395000356653 /* LazyBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AFB8AB91DAE395000356653 /* LazyBox.swift */; };
 		3AFB8AC01DAE395000356653 /* LazyBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AFB8AB91DAE395000356653 /* LazyBox.swift */; };
+		3D7559231DF9B03B00397CBF /* MomentCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7559221DF9B03B00397CBF /* MomentCache.swift */; };
 		53C2DA3B1C99956E00604118 /* MomentFromNow.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 53CB62721C919E8000BA62E9 /* MomentFromNow.bundle */; };
 		53C2DA3C1C99957E00604118 /* MomentFromNow.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 53CB62721C919E8000BA62E9 /* MomentFromNow.bundle */; };
 		53CB62741C919E8000BA62E9 /* MomentFromNow.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 53CB62721C919E8000BA62E9 /* MomentFromNow.bundle */; };
@@ -111,6 +112,7 @@
 		3AB0FB8A1A6D1629006449DB /* TimeUnit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeUnit.swift; sourceTree = "<group>"; };
 		3AB0FB8C1A6D1644006449DB /* Duration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Duration.swift; sourceTree = "<group>"; };
 		3AFB8AB91DAE395000356653 /* LazyBox.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LazyBox.swift; sourceTree = "<group>"; };
+		3D7559221DF9B03B00397CBF /* MomentCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MomentCache.swift; sourceTree = "<group>"; };
 		53CB62721C919E8000BA62E9 /* MomentFromNow.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = MomentFromNow.bundle; sourceTree = "<group>"; };
 		E2532BEC1C358B4E00392471 /* SwiftMoment macOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwiftMoment macOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E2F6254B1C357BC00057AE1D /* SwiftMoment.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftMoment.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -209,6 +211,7 @@
 				3A6429C31A6D2C8700B10310 /* Operators.swift */,
 				3A6429C51A6D33FA00B10310 /* Extensions.swift */,
 				3AFB8AB91DAE395000356653 /* LazyBox.swift */,
+				3D7559221DF9B03B00397CBF /* MomentCache.swift */,
 			);
 			path = SwiftMoment;
 			sourceTree = "<group>";
@@ -572,6 +575,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3D7559231DF9B03B00397CBF /* MomentCache.swift in Sources */,
 				3A6429C61A6D33FA00B10310 /* Extensions.swift in Sources */,
 				3AB0FB8D1A6D1644006449DB /* Duration.swift in Sources */,
 				3A6429C41A6D2C8700B10310 /* Operators.swift in Sources */,

--- a/SwiftMoment/SwiftMoment/Moment.swift
+++ b/SwiftMoment/SwiftMoment/Moment.swift
@@ -11,7 +11,6 @@
 
 import Foundation
 
-
 /// Returns a moment representing the current instant in time at the current timezone.
 /// This is the most common way to create a new Moment value:
 ///
@@ -176,8 +175,7 @@ public func moment(_ params: [Int],
                    timeZone: TimeZone = TimeZone.current,
                    locale: Locale = Locale.autoupdatingCurrent) -> Moment? {
     if params.count > 0 {
-        var calendar = Calendar.current
-        calendar.timeZone = timeZone
+        let calendar = MomentCache.calendar(timeZone: timeZone, locale: locale)
         var components = DateComponents()
         components.year = params[0]
 
@@ -455,9 +453,7 @@ public struct Moment: Comparable {
 
     /// Year of the current instance.
     public var year: Int {
-        var cal = Calendar.current
-        cal.timeZone = timeZone
-        cal.locale = locale
+        let cal = MomentCache.calendar(timeZone: timeZone, locale: locale)
         let param: Set<Calendar.Component> = [.year]
         let components = cal.dateComponents(param, from: date)
         return components.year!
@@ -465,9 +461,7 @@ public struct Moment: Comparable {
 
     /// Month (1-12) of the current instance.
     public var month: Int {
-        var cal = Calendar.current
-        cal.timeZone = timeZone
-        cal.locale = locale
+		let cal = MomentCache.calendar(timeZone: timeZone, locale: locale)
         let param: Set<Calendar.Component> = [.month]
         let components = cal.dateComponents(param, from: date)
         return components.month!
@@ -482,9 +476,7 @@ public struct Moment: Comparable {
 
     /// Day of the month (1-31) of the current instance.
     public var day: Int {
-        var cal = Calendar.current
-        cal.timeZone = timeZone
-        cal.locale = locale
+		let cal = MomentCache.calendar(timeZone: timeZone, locale: locale)
         let param: Set<Calendar.Component> = [.day]
         let components = cal.dateComponents(param, from: date)
         return components.day!
@@ -492,9 +484,7 @@ public struct Moment: Comparable {
 
     /// Hour (0-23) of the current instance.
     public var hour: Int {
-        var cal = Calendar.current
-        cal.timeZone = timeZone
-        cal.locale = locale
+		let cal = MomentCache.calendar(timeZone: timeZone, locale: locale)
         let param: Set<Calendar.Component> = [.hour]
         let components = cal.dateComponents(param, from: date)
         return components.hour!
@@ -502,9 +492,7 @@ public struct Moment: Comparable {
 
     /// Minutes (0-59) of the current instance.
     public var minute: Int {
-        var cal = Calendar.current
-        cal.timeZone = timeZone
-        cal.locale = locale
+		let cal = MomentCache.calendar(timeZone: timeZone, locale: locale)
         let param: Set<Calendar.Component> = [.minute]
         let components = cal.dateComponents(param, from: date)
         return components.minute!
@@ -512,9 +500,7 @@ public struct Moment: Comparable {
 
     /// Seconds (0-59) of the current instance.
     public var second: Int {
-        var cal = Calendar.current
-        cal.timeZone = timeZone
-        cal.locale = locale
+		let cal = MomentCache.calendar(timeZone: timeZone, locale: locale)
         let param: Set<Calendar.Component> = [.second]
         let components = cal.dateComponents(param, from: date)
         return components.second!
@@ -522,9 +508,7 @@ public struct Moment: Comparable {
 
     /// Weekday (1-7, Sunday is 1) of the current instance.
     public var weekday: Int {
-        var cal = Calendar.current
-        cal.timeZone = timeZone
-        cal.locale = locale
+		let cal = MomentCache.calendar(timeZone: timeZone, locale: locale)
         let param: Set<Calendar.Component> = [.weekday]
         let components = cal.dateComponents(param, from: date)
         return components.weekday!
@@ -543,9 +527,7 @@ public struct Moment: Comparable {
     /// within the next larger calendar unit, such as the month.
     /// For example, 2 is the weekday ordinal unit for the second Friday of the month."
     public var weekdayOrdinal: Int {
-        var cal = Calendar.current
-        cal.locale = locale
-        cal.timeZone = timeZone
+		let cal = MomentCache.calendar(timeZone: timeZone, locale: locale)
         let param: Set<Calendar.Component> = [.weekdayOrdinal]
         let components = cal.dateComponents(param, from: date)
         return components.weekdayOrdinal!
@@ -553,9 +535,7 @@ public struct Moment: Comparable {
 
     /// Number of the week in the current year of the current instance.
     public var weekOfYear: Int {
-        var cal = Calendar.current
-        cal.locale = locale
-        cal.timeZone = timeZone
+		let cal = MomentCache.calendar(timeZone: timeZone, locale: locale)
         let param: Set<Calendar.Component> = [.weekOfYear]
         let components = cal.dateComponents(param, from: date)
         return components.weekOfYear!
@@ -563,9 +543,7 @@ public struct Moment: Comparable {
 
     /// Quarter of the year of the current instance.
     public var quarter: Int {
-        var cal = Calendar.current
-        cal.locale = locale
-        cal.timeZone = timeZone
+		let cal = MomentCache.calendar(timeZone: timeZone, locale: locale)
         let param: Set<Calendar.Component> = [.quarter]
         let components = cal.dateComponents(param, from: date)
         return components.quarter!
@@ -903,9 +881,7 @@ public struct Moment: Comparable {
     ///
     /// - returns: A new Moment instance.
     public func startOf(_ unit: TimeUnit) -> Moment {
-        var cal = Calendar.current
-        cal.locale = locale
-        cal.timeZone = timeZone
+		let cal = MomentCache.calendar(timeZone: timeZone, locale: locale)
         var newDate: Date?
         let param: Set<Calendar.Component> = [.year, .month, .weekday, .day, .hour, .minute, .second]
         var components = cal.dateComponents(param, from: date)

--- a/SwiftMoment/SwiftMoment/MomentCache.swift
+++ b/SwiftMoment/SwiftMoment/MomentCache.swift
@@ -1,0 +1,47 @@
+//
+//  MomentCache.swift
+//  SwiftMoment
+//
+//  Created by Florent Pillet on 08/12/16.
+//  Copyright © 2016 Adrian Kosmaczewski. All rights reserved.
+//
+
+import Foundation
+
+internal class MomentCache {
+	// the key we use to cache calendars for a common TimeZone / Locale pair
+	private struct Key : Hashable, Equatable {
+		let tz: TimeZone
+		let locale: Locale
+		
+		var hashValue: Int {
+			return tz.hashValue ^ locale.hashValue
+		}
+		static func ==(lhs: Key, rhs: Key) -> Bool {
+			return lhs.tz == rhs.tz && lhs.locale == rhs.locale
+		}
+	}
+	
+	// our cache and the lock to access it
+	private static var calendarCache = [Key:Calendar]()
+	private static var lock = NSLock()
+	
+	// create calendars on demand; in most cases, will return the same calendar
+	static func calendar(timeZone: TimeZone = defaultTimezone, locale: Locale = defaultLocale) -> Calendar {
+		lock.lock()
+		defer { lock.unlock() }
+		let key = Key(tz: timeZone, locale: locale)
+		if let calendar = calendarCache[key] {
+			return calendar
+		}
+		var calendar = Calendar.autoupdatingCurrent
+		calendar.timeZone = timeZone
+		calendar.locale = locale
+		calendarCache[key] = calendar
+		return calendar
+	}
+	
+	static var defaultCalendar : Calendar = { Calendar.autoupdatingCurrent }()
+	static var defaultLocale : Locale = { Locale.autoupdatingCurrent }()
+	static var defaultTimezone : TimeZone = { TimeZone.autoupdatingCurrent }()
+}


### PR DESCRIPTION
## Description
This PR makes a local cache of calendars (in most cases, only one will be use with default parameters) to provide a huge speedup in most operations. Instantiating a new calendar with `Calendar.current` is a very expensive operation. Doing a lot of time/date manipulation with SwiftMoment was very slow until I factored out the calendar creation.

Since SwiftMoment sets the timezone and locale on calendars it uses, I chose to make a keyed cache per (timezone, locale) couple. Calendars returned by the cache should not be modified (as they are shared) but since it is purely internal to SwiftMoment, we should be fine.

## Motivation and Context
This fixes a slowness problem.

## How Has This Been Tested?
I did time nearly 4000 access to Calendar in real code. Here are the timings before and after the fix:

totalComputeTime = 0.641861613999999, calendars = 3933
totalComputeTime = 0.259146789, calendars = 3933

This shows nearly a threefold speedup. Actual numbers are even better because other uses of Moments throughout my code were slowing it down a lot.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code does not leave warnings unattended.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


