### PR TITLE
Fix using preferredLanguages for Russian

### DIFF
--- a/SwiftMoment/SwiftMoment/MomentFromNow.swift
+++ b/SwiftMoment/SwiftMoment/MomentFromNow.swift
@@ -146,11 +146,11 @@ extension Moment {
     }
 
     private func getLocaleFormatUnderscoresWithValue(_ value: Double) -> String {
-        guard let localeCode = Locale.preferredLanguages.first else {
+        guard let languageCode = self.locale.languageCode else {
             return ""
         }
 
-        if localeCode == "ru" {
+        if languageCode == "ru" {
             let xy = Int(floor(value)) % 100
             let y = Int(floor(value)) % 10
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
localeCode never will be "ru" in iOS 9

## Description
https://developer.apple.com/library/content/technotes/tn2418/_index.html

With iOS 9, the results returned by Locale.preferredLanguages() can differ from previous releases. In iOS 8 and earlier, only certain language, script, and region combinations were returned by this API. However, in iOS 9, more combinations of language, script, and region are permitted. This change is also applied to macOS Sierra, watchOS 3, and tvOS 10.

For example, when a user has configured their iOS device with language set to English and region set to India, Locale.preferredLanguages() will now return [ "en-IN" ], instead of [ "en" ]. This allows for smarter language fallbacks; for this user, if an app doesn’t support en-IN as a localization, but does support en-GB, the fallback mechanism will select en-GB instead of en.
