### PR TITLE
Fixed iSO8601 string parsing bug: 'Z' timezone ignored when milliseco…

### DIFF
--- a/SwiftMoment/SwiftMoment/Moment.swift
+++ b/SwiftMoment/SwiftMoment/Moment.swift
@@ -91,9 +91,9 @@ public func moment(_ stringDate: String,
     // https://github.com/moment/moment/blob/develop/moment.js
     let formats = [
         isoFormat,
+        "yyyy-MM-dd'T'HH:mm:ss.SSSZ",
         "yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'",
         "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'SSS'Z'",
-        "yyyy-MM-dd'T'HH:mm:ss.SSSZ",
         "yyyy-MM-dd",
         "h:mm:ss A",
         "h:mm A",

--- a/SwiftMoment/SwiftMomentTests/MomentTests.swift
+++ b/SwiftMoment/SwiftMomentTests/MomentTests.swift
@@ -109,6 +109,18 @@ class MomentTests: XCTestCase {
         XCTAssertEqual(obj.minute, 0, "The minute should be zero")
         XCTAssertEqual(obj.second, 0, "The second should be zero")
     }
+    
+    func testCanCreateMomentsWithISO8601WithMilliseconds() {
+        let timeZone = TimeZone(abbreviation: "GMT+03")!
+        let stringWithMilliseconds    = "2017-11-28T13:25:43.123Z"
+        let obj = moment(stringWithMilliseconds, timeZone:timeZone)!
+        XCTAssertEqual(obj.year, 2017, "The year should match")
+        XCTAssertEqual(obj.month, 11, "The month should match")
+        XCTAssertEqual(obj.day, 28, "The day should match")
+        XCTAssertEqual(obj.hour, 16, "The hour should be 16")
+        XCTAssertEqual(obj.minute, 25, "The minute should match")
+        XCTAssertEqual(obj.second, 43, "The second should match")
+    }
 
     func testCanCreateWeirdDateFromComponents() {
         let timeZone = TimeZone(abbreviation: "GMT+01")!


### PR DESCRIPTION
…nds specified in iSO8601 date (i.e. date parsed as date in current/custom timezone even if 'Z' presented in string date format)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If we specify is8601 string with milliseconds AND with zero offset ('Z' in format), parser will ignore zero offset and interpret date as date with local timezone offset.
So if we have current timezone +5GMT and we type 
    moment("2017-11-28T13:25:43.123Z")!.date
we get this: 
    2017-11-28 13:25:43 GMT+05:00
But should be 
    2017-11-28 18:25:43 GMT+05:00

I just replaced two line with each other in parsing formats array. That's all. I don't know if it legal to do so, and I ask you to check it out. All tests passed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Should fix this: https://github.com/akosma/SwiftMoment/issues/85

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I created new test `testCanCreateMomentsWithISO8601WithMilliseconds` in MomentTests.swift
All other tests performs correctly except `testDurationDescription` which seems never pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code does not leave warnings unattended.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
