### PR TITLE
Fix typo for norwegian localization

### DIFF
--- a/SwiftMoment/SwiftMoment/MomentFromNow.bundle/nb.lproj/NSDateTimeAgo.strings
+++ b/SwiftMoment/SwiftMoment/MomentFromNow.bundle/nb.lproj/NSDateTimeAgo.strings
@@ -77,7 +77,7 @@
 "A minute ago" = "Et minutt siden";
 
 /* No comment provided by engineer. */
-"An hour ago" = "En time siden";
+"An hour ago" = "Én time siden";
 
 /* No comment provided by engineer. */
 "Just now" = "Nå";


### PR DESCRIPTION
## Description
In norwegian, when talking about numbers you use `én` instead of `en`

## How Has This Been Tested?
It hasn't been tested, relying on CI test

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code does not leave warnings unattended.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.