### PR TITLE
SwiftMoment as Swift package

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git/
+.build/
+!.build/checkouts/
+!.build/repositories/
+!.build/workspace-state.json

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,9 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
+
+
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM swift:4.1
+
+WORKDIR /package
+
+COPY . ./
+
+RUN swift package resolve
+RUN swift package clean
+CMD swift test --parallel

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "SwiftMoment",
+    products: [
+        .library(name: "SwiftMoment", targets: ["SwiftMoment"]),
+    ],
+    dependencies: [
+        // none
+    ],
+    targets: [
+        .target(name: "SwiftMoment", path: ".", sources: ["SwiftMoment/SwiftMoment"]),
+        .testTarget(name: "SwiftMomentTests", dependencies: ["SwiftMoment"], path: ".", sources: ["SwiftMoment/SwiftMomentTests"]),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,21 @@ your Podfile:
 pod 'SwiftMoment'
 ```
 
+SwiftMoment can also be used via the [Swift Package Manager](https://swift.org/package-manager/). 
+Just add it to the dependencies in your Package.swift file:
+
+```Swift
+let package = Package(
+    name: "MyPackage",
+    dependencies: [
+        ...
+        .package(url: "https://github.com/akosma/SwiftMoment.git", from: "0.7.1"),
+    ],
+    ...
+)
+```
+
+
 ## Mac OS X Notes
 
 - Drag the created .framework file into the Xcode Project, be sure to tick 'Copy Files to Directory'
@@ -100,6 +115,13 @@ be subtracted from one another (which yields a `Duration`) and
 
 Swift Moment includes a suite of tests showing how to use the different
 functions of the framework.
+
+To run the Linux tests in a macOS environment, please use the included Dockerfile:
+
+```
+docker build --tag swiftmoment .
+docker run --rm swiftmoment
+```
 
 ## Playground
 

--- a/SwiftMoment/SwiftMomentTests/LinuxMain.swift
+++ b/SwiftMoment/SwiftMomentTests/LinuxMain.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+import SwiftMomentTests
+
+var tests = [XCTestCaseEntry]()
+tests += __allTests()
+XCTMain(tests)

--- a/SwiftMoment/SwiftMomentTests/XCTestManifests.swift
+++ b/SwiftMoment/SwiftMomentTests/XCTestManifests.swift
@@ -1,0 +1,123 @@
+import XCTest
+
+// swift test --generate-linuxmain
+
+extension DurationTests {
+    static let __allTests = [
+        ("testCanAddAndSubstractDurations", testCanAddAndSubstractDurations),
+        ("testCanCreateDurationsFromDoubles", testCanCreateDurationsFromDoubles),
+        ("testCanCreateDurationsFromIntegers", testCanCreateDurationsFromIntegers),
+        ("testCanGenerateMomentAgo", testCanGenerateMomentAgo),
+        ("testDurationDescription", testDurationDescription),
+        ("testDurationProperties", testDurationProperties),
+        ("testSinceReturnsDuration", testSinceReturnsDuration),
+    ]
+}
+
+extension ExtensionsTests {
+    static let __allTests = [
+        ("testCanReturnDaysDuration", testCanReturnDaysDuration),
+        ("testCanReturnDaysDurationAsDouble", testCanReturnDaysDurationAsDouble),
+        ("testCanReturnHoursDuration", testCanReturnHoursDuration),
+        ("testCanReturnHoursDurationAsDouble", testCanReturnHoursDurationAsDouble),
+        ("testCanReturnMinutesDuration", testCanReturnMinutesDuration),
+        ("testCanReturnMinutesDurationAsDouble", testCanReturnMinutesDurationAsDouble),
+        ("testCanReturnMonthsDuration", testCanReturnMonthsDuration),
+        ("testCanReturnMonthsDurationAsDouble", testCanReturnMonthsDurationAsDouble),
+        ("testCanReturnQuartersDuration", testCanReturnQuartersDuration),
+        ("testCanReturnQuartersDurationAsDouble", testCanReturnQuartersDurationAsDouble),
+        ("testCanReturnSecondsDuration", testCanReturnSecondsDuration),
+        ("testCanReturnSecondsDurationAsDouble", testCanReturnSecondsDurationAsDouble),
+        ("testCanReturnWeeksDuration", testCanReturnWeeksDuration),
+        ("testCanReturnWeeksDurationAsDouble", testCanReturnWeeksDurationAsDouble),
+        ("testCanReturnYearsDuration", testCanReturnYearsDuration),
+        ("testCanReturnYearsDurationAsDouble", testCanReturnYearsDurationAsDouble),
+    ]
+}
+
+extension FromNowTests {
+    static let __allTests = [
+        ("testFromNowEnglish", testFromNowEnglish),
+        ("testFromNowHebrew", testFromNowHebrew),
+    ]
+}
+
+extension MomentTests {
+    static let __allTests = [
+        ("testAddingInt", testAddingInt),
+        ("testAddingOtherValues", testAddingOtherValues),
+        ("testAdditionAndSubstractionAreInverse", testAdditionAndSubstractionAreInverse),
+        ("testAddSmallTimeSpans", testAddSmallTimeSpans),
+        ("testCanCompareMoments", testCanCompareMoments),
+        ("testCanCreateMomentsWithFiveComponents", testCanCreateMomentsWithFiveComponents),
+        ("testCanCreateMomentsWithFourComponents", testCanCreateMomentsWithFourComponents),
+        ("testCanCreateMomentsWithOneComponent", testCanCreateMomentsWithOneComponent),
+        ("testCanCreateMomentsWithSixComponents", testCanCreateMomentsWithSixComponents),
+        ("testCanCreateMomentsWithThreeComponents", testCanCreateMomentsWithThreeComponents),
+        ("testCanCreateMomentsWithTwoComponents", testCanCreateMomentsWithTwoComponents),
+        ("testCanCreateWeirdDateFromComponents", testCanCreateWeirdDateFromComponents),
+        ("testCanGetParametersByGetter", testCanGetParametersByGetter),
+        ("testCreateDateWithDictionary", testCreateDateWithDictionary),
+        ("testDescriptions", testDescriptions),
+        ("testDifferentSyntaxesToAddAndSubstract", testDifferentSyntaxesToAddAndSubstract),
+        ("testDurationVSTimeUnitDoesNotMatterForDaysHoursMinutesSeconds", testDurationVSTimeUnitDoesNotMatterForDaysHoursMinutesSeconds),
+        ("testEmptyArrayOfComponentsYieldsNilMoment", testEmptyArrayOfComponentsYieldsNilMoment),
+        ("testEmptyDictionaryOfComponentsYieldsNilMoment", testEmptyDictionaryOfComponentsYieldsNilMoment),
+        ("testEndOfDay", testEndOfDay),
+        ("testEndOfMonth", testEndOfMonth),
+        ("testEndOfWeek", testEndOfWeek),
+        ("testEndOfYear", testEndOfYear),
+        ("testEpoch", testEpoch),
+        ("testEqualityIsCommutative", testEqualityIsCommutative),
+        ("testFindMaximumMoment", testFindMaximumMoment),
+        ("testFindMinimumMoment", testFindMinimumMoment),
+        ("testFormatDates", testFormatDates),
+        ("testFormatDatesWithLocale", testFormatDatesWithLocale),
+        ("testFormatWithTimeZone", testFormatWithTimeZone),
+        ("testFutureMoment", testFutureMoment),
+        ("testGibberishIsInvalid", testGibberishIsInvalid),
+        ("testLocaleSupport", testLocaleSupport),
+        ("testMaximumWithoutParametersReturnsNil", testMaximumWithoutParametersReturnsNil),
+        ("testMinimumWithoutParametersReturnsNil", testMinimumWithoutParametersReturnsNil),
+        ("testMomentWithTimeZone", testMomentWithTimeZone),
+        ("testPastMoment", testPastMoment),
+        ("testPublicDate", testPublicDate),
+        ("testPublicLocale", testPublicLocale),
+        ("testPublicTimeZone", testPublicTimeZone),
+        ("testStartOfDay", testStartOfDay),
+        ("testStartOfHour", testStartOfHour),
+        ("testStartOfMinute", testStartOfMinute),
+        ("testStartOfMonth", testStartOfMonth),
+        ("testStartOfSecond", testStartOfSecond),
+        ("testStartOfWeek", testStartOfWeek),
+        ("testStartOfYear", testStartOfYear),
+        ("testSubstractSmallTimeSpans", testSubstractSmallTimeSpans),
+        ("testTheMomentIsNow", testTheMomentIsNow),
+        ("testTimeZoneChangeAdd", testTimeZoneChangeAdd),
+        ("testTimeZoneChangeEndOf", testTimeZoneChangeEndOf),
+        ("testTimeZoneChangesPreserveMomentInGMT", testTimeZoneChangesPreserveMomentInGMT),
+        ("testTimeZoneChangeStartOf", testTimeZoneChangeStartOf),
+        ("testTimeZoneChangeSubtract", testTimeZoneChangeSubtract),
+        ("testTimeZoneStartOfDay", testTimeZoneStartOfDay),
+        ("testTransformTimeZone", testTransformTimeZone),
+        ("testUsingWrongParameterNameYieldsNil", testUsingWrongParameterNameYieldsNil),
+        ("testUTCMomentSupport", testUTCMomentSupport),
+        ("testWrongArrayReturnsNil", testWrongArrayReturnsNil),
+        ("testWrongFormatParametersReturnNil", testWrongFormatParametersReturnNil),
+        ("testWrongUnitInAddReturnsSelf", testWrongUnitInAddReturnsSelf),
+        ("testWrongUnitInEndOfReturnsSelf", testWrongUnitInEndOfReturnsSelf),
+        ("testWrongUnitInStartOfReturnsSelf", testWrongUnitInStartOfReturnsSelf),
+        ("testWrongUnitInSubstractReturnsSelf", testWrongUnitInSubstractReturnsSelf),
+    ]
+}
+
+#if !os(macOS)
+public func __allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(DurationTests.__allTests),
+        testCase(ExtensionsTests.__allTests),
+        testCase(FromNowTests.__allTests),
+        testCase(MomentTests.__allTests),
+    ]
+}
+#endif


### PR DESCRIPTION
Added configuration to allow the use of SwiftMoment as a Swift package.

## Description

Pretty straight forward job.

## Motivation and Context

I have a need to use SwiftMoment in a Vapor app.

## How Has This Been Tested?

It can be used as a dependency:

```Swift
// swift-tools-version:4.0
import PackageDescription

let package = Package(
    name: "MyApp",
    dependencies: [
        // 💧 A server-side Swift web framework.
        .package(url: "https://github.com/vapor/vapor.git", from: "3.0.0"),

        // 🍃 An expressive, performant, and extensible templating language built for Swift.
        .package(url: "https://github.com/vapor/leaf.git", from: "3.0.0"),
        
        // 🖋 Swift ORM framework (queries, models, and relations)
        .package(url: "https://github.com/vapor/fluent-postgresql.git", from: "1.0.0"),

        // SwiftMoment - A time and calendar manipulation library
        .package(url: "https://github.com/pardel/SwiftMoment.git", from: "0.7.1"),
    ],
    targets: [
        .target(name: "App", dependencies: ["Leaf", "FluentPostgreSQL", "Vapor", "SwiftMoment"]),
        .target(name: "Run", dependencies: ["App"]),
        .testTarget(name: "AppTests", dependencies: ["App"])
    ]
)
```


## Possible problem

The Swift Package manager doesn't like the v.X.X.X format for versioning but prefers X.X.X so a tag without the `v` will need to be also created. eg: https://github.com/pardel/SwiftMoment/releases
